### PR TITLE
CI: don't build docs as part of primary CI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,6 @@ jobs:
           GAPBRANCH: ${{ matrix.gap-branch }}
           GAP_PKGS_TO_BUILD: "io profiling grape cohomolo"
       - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/build-pkg-docs@v1
       - uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
They are still built as part of the CI docs which tests building the docs...

This matches what most other packages do.

With this the failures in PR #61 are at least restricted to one job instead of all.