### PR TITLE
Load recog for tests

### DIFF
--- a/tst/testTables.g
+++ b/tst/testTables.g
@@ -7,6 +7,7 @@
 
 # Some tests need to check for graph isomorphism using grape
 LoadPackage("cohomolo");
+LoadPackage("recog");
 LoadPackage( "LINS" );
 ReadPackage( "LINS", "gap/createTables.gi");;
 

--- a/tst/testTables.g
+++ b/tst/testTables.g
@@ -5,8 +5,9 @@
 # metadata in PackageInfo.g.
 #
 
-# Some tests need to check for graph isomorphism using grape
+# The computation of the tables (targets) requires the computation of schur multipliers
 LoadPackage("cohomolo");
+# Makes the computation of the tables (targets) faster
 LoadPackage("recog");
 LoadPackage( "LINS" );
 ReadPackage( "LINS", "gap/createTables.gi");;

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -8,6 +8,7 @@
 # Some tests need to check for graph isomorphism using grape
 LoadPackage( "grape" );
 LoadPackage("cohomolo");
+LoadPackage("recog");
 LoadPackage( "LINS" );
 ReadPackage( "LINS", "gap/createTables.gi");;
 

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -7,7 +7,9 @@
 
 # Some tests need to check for graph isomorphism using grape
 LoadPackage( "grape" );
+# The computation of the tables (targets) requires the computation of schur multipliers
 LoadPackage("cohomolo");
+# Makes the computation of the tables (targets) faster
 LoadPackage("recog");
 LoadPackage( "LINS" );
 ReadPackage( "LINS", "gap/createTables.gi");;


### PR DESCRIPTION
The [test-suite](https://github.com/gap-system/PackageDistro/actions/runs/8284707745/job/22671331808) in the GAP-Package-Distro fails for OnlyNeeded.

My guess is, that the package recog needs to be loaded.

The failed test is just about checking whether the stored tables (targets) can be recreated via the provided code.