### PR TITLE
Revert "CI: disable failing test"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,11 +39,9 @@ jobs:
       - uses: gap-actions/build-pkg@v1
       - uses: gap-actions/build-pkg-docs@v1
       - uses: gap-actions/run-pkg-tests@v3
-      # Disabled the "only-needed" tests for now, as they run into a GAP
-      # library warning about "Alternating recognition needed"
-      #- uses: gap-actions/run-pkg-tests@v3
-      #  with:
-      #    only-needed: true
+      - uses: gap-actions/run-pkg-tests@v3
+        with:
+          only-needed: true
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
This is a reminder that we should investigate the failures and decide
what to do about them properly.
